### PR TITLE
Fixed my fix

### DIFF
--- a/scripts/recon_enum/smbver.sh
+++ b/scripts/recon_enum/smbver.sh
@@ -7,8 +7,8 @@
 #Notes:
 # Will sometimes not capture or will print multiple
 # lines. May need to run a second time for success.
-if [ -z $1 ]; then echo "Usage: ./smbver.sh RHOST {RPORT}" && exit; else rhost=$1; fi
+if [ -z $1 ]; then echo "Usage: ./smbver.sh RHOST {RPORT}"; else rhost=$1; 
 if [ ! -z $2 ]; then rport=$2; else rport=139; fi
 tcpdump -s0 -n -i tap0 src $rhost and port $rport -A -c 10 2>/dev/null | grep -i "samba\|s.a.m" | tr -d '.' | grep -oP 'UnixSamba.*[0-9a-z]' | tr -d '\n' & echo -n "$rhost: " &
 echo "exit" | smbclient -L $rhost 1>/dev/null 2>/dev/null
-echo "" && sleep .1
+echo "" && sleep .1; fi


### PR DESCRIPTION
Moved the end of the first if/then to the end of the whole script. Now it run any of the middle code when ran with no options from the command line, the second if/then and the tcpdump are inside the first if/then.

The script will now longer exit and close the terminal session when ran with no options. It will print the usage and exit.